### PR TITLE
fix env variable for passing custom port

### DIFF
--- a/opt/with_ngrok
+++ b/opt/with_ngrok
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-port=${PORT:-9090}
+port=${AUX_PORT:-9090}
 
 if [ -n "$NGROK_API_TOKEN" ]; then
   NGROK_OPTS="${NGROK_OPTS} --authtoken ${NGROK_API_TOKEN}"


### PR DESCRIPTION
Docs mention `AUX_PORT` env variable, which allows setting custom port, which ngrok should expose. `PORT` was used instead, however. Wouldn't be that much of an issue, if not the fact, that Heroku already sets `PORT` variable to pass a port to which web process can connect ;)